### PR TITLE
Adding time delay & value update on gspread (Google Sheet Read) 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,6 +50,10 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
+      # A short time delay to ensure the image can be pulled after pushed 
+      - name: Wait for image availability 
+        run: sleep 20
+
       # Pull the image again so it's available locally
       - name: Pull Docker image
         run: |

--- a/Readme.md
+++ b/Readme.md
@@ -43,7 +43,7 @@ plAccounts.forEach(account => {
 Copy the information returned by the console to extract your ProjectionLab account IDs. 
 
 ## Prepare your Google spreadsheet
-1. Share your Google spreadsheet (that you want to sync to PL) with the Google service account you just created. 
+1. Share your Google spreadsheet (that you want to sync to PL) with the Google service account you just created. **Important**: Share with Editor permissions. The script writes a temporary value to the Sheet (then reverts the change) which triggers a refresh of the Sheet. Otherwise, stale data could be queried. 
 2. Create a new, dedicated tab to sync to ProjectionLab. 
 3. Create the following four columns. Column headers are required as the script truncates the first row:
 

--- a/Readme.md
+++ b/Readme.md
@@ -80,6 +80,7 @@ services:
       - PL_URL=http://172.16.1.98:8099/register
       - SHEETS_FILENAME=My Financial Plan
       - SHEETS_WORKSHEET=PLsync
+      - TZ=America/Regina
       - TIME_DELAY=10
     restart: unless-stopped
 ```
@@ -87,6 +88,7 @@ Notes:
 - The ProjectionLab URL must point to the /register login page, as the Selenium script is looking for specific buttons to click to log in. 
 - `SHEETS_FILENAME` and `SHEETS_WORKSHEET` should be self-explanatory. Spaces are OK here, e.g. `SHEETS_FILENAME=Financial Plan`
 - `TIME_DELAY` is the number of seconds between opening the PL_URL and attempting to enter the username/password. This should not be too small (10 seconds is default) or the script will try and log in or publish values before the content renders in the browser.
+- Time zone `TZ` is required to ensure the Docker container is running in the same time zone as your ProjectionLab instance. 
 - If you use Docker Run instead of Docker Compose, see https://www.decomposerize.com/ or a similar site.
 
 ## How do I know it's working? 

--- a/sheets2projectionlab.py
+++ b/sheets2projectionlab.py
@@ -81,6 +81,9 @@ def main():
     logging.debug("Accessing specified worksheet...")
     sheet_instance = sheet.worksheet(sheets_worksheet)
 
+    logging.info(f"Waiting {time_delay} seconds to (hopefully) ensure the sheet updates.")
+    time.sleep(time_delay)
+
     # List of accounts and balances to update
     # Should be a list of values matching this string:window.projectionlabPluginAPI.updateAccount('xxxxxxxxx-accountid', { balance: 33019.78 }, { key: 'xxxxxxxxxxx-apikey' })
     # Assumes Column 4 and that people are matching my template. 

--- a/sheets2projectionlab.py
+++ b/sheets2projectionlab.py
@@ -84,10 +84,20 @@ def main():
     logging.info(f"Waiting {time_delay} seconds to (hopefully) ensure the sheet updates.")
     time.sleep(time_delay)
 
+    logging.info(f"Writing dummy value to cell A1 to attempt to trigger a spreadsheet update")
+
+    # Trigger refresh by updating a dummy cell (per ChatGPT)
+    dummy_cell = "A1" #A1 should be a header cell, OK to overwrite
+    original_value = sheet_instance.acell(dummy_cell).value  # Backup original value
+    sheet_instance.update_acell(dummy_cell, "Refresh Trigger")
+    time.sleep(1)
+    sheet_instance.update_acell(dummy_cell, original_value)  # Restore original value
+    time.sleep(1)
+
     # List of accounts and balances to update
     # Should be a list of values matching this string:window.projectionlabPluginAPI.updateAccount('xxxxxxxxx-accountid', { balance: 33019.78 }, { key: 'xxxxxxxxxxx-apikey' })
     # Assumes Column 4 and that people are matching my template. 
-    logging.debug("Fetching update list from Google Sheets...")
+    logging.debug("Fetching updated balances from Google Sheets...")
     update_list = sheet_instance.col_values(4)
     update_list = validate_update_commands(update_list[1:])  # Trim the header row and validate
     logging.info(f"Retrieved {len(update_list)} entries from the update list.")

--- a/sheets2projectionlab.py
+++ b/sheets2projectionlab.py
@@ -35,7 +35,7 @@ def redact_api_key(command):
 def main(): 
     # Set up logging configuration
     logging.basicConfig(
-        level=logging.DEBUG,  # Set level to DEBUG for verbose output
+        level=logging.INFO,  # Set level to INFO for verbose output (DEBUG could expose PL creds in logs)
         format='%(asctime)s - %(levelname)s - %(message)s',
         datefmt='%Y-%m-%d %H:%M:%S'
     )
@@ -71,14 +71,14 @@ def main():
     creds = ServiceAccountCredentials.from_json_keyfile_name(keyfile_path, scope)
 
     # authorize the clientsheet 
-    logging.debug("Authorizing Google credentials...")
+    logging.info("Authorizing Google credentials...")
     client = gspread.authorize(creds)
 
     # get the instance of the Spreadsheet
-    logging.debug("Opening Google Sheets spreadsheet...")
+    logging.info("Opening Google Sheets spreadsheet...")
     sheet = client.open(sheets_filename)
 
-    logging.debug("Accessing specified worksheet...")
+    logging.info("Accessing specified worksheet...")
     sheet_instance = sheet.worksheet(sheets_worksheet)
 
     logging.info(f"Waiting {time_delay} seconds to (hopefully) ensure the sheet updates.")
@@ -86,7 +86,7 @@ def main():
 
     logging.info(f"Writing dummy value to cell A1 to attempt to trigger a spreadsheet update")
 
-    # Trigger refresh by updating a dummy cell (per ChatGPT)
+    # Trigger refresh of functions like =GOOGLEFINANCE() by updating a dummy cell (per ChatGPT)
     dummy_cell = "A1" #A1 should be a header cell, OK to overwrite
     original_value = sheet_instance.acell(dummy_cell).value  # Backup original value
     sheet_instance.update_acell(dummy_cell, "Refresh Trigger")
@@ -98,7 +98,7 @@ def main():
     # List of accounts and balances to update
     # Should be a list of values matching this string:window.projectionlabPluginAPI.updateAccount('xxxxxxxxx-accountid', { balance: 33019.78 }, { key: 'xxxxxxxxxxx-apikey' })
     # Assumes Column 4 and that people are matching my template. 
-    logging.debug("Fetching updated balances from Google Sheets...")
+    logging.info("Fetching updated balances from Google Sheets...")
     update_list = sheet_instance.col_values(4)
     update_list = validate_update_commands(update_list[1:])  # Trim the header row and validate
     logging.info(f"Retrieved {len(update_list)} entries from the update list.")
@@ -123,32 +123,32 @@ def main():
     chrome_options.add_argument('--disable-gpu')
 
     try:
-        logging.debug("Starting Chrome WebDriver...")
+        logging.info("Starting Chrome WebDriver...")
         driver = webdriver.Chrome(options=chrome_options)
 
-        logging.debug(f"Navigating to ProjectionLab URL: {projectionlab_url}")
+        logging.info(f"Navigating to ProjectionLab URL: {projectionlab_url}")
         driver.get(projectionlab_url)
 
         logging.info(f"Waiting {time_delay} seconds for the page to load.")
         time.sleep(time_delay)
 
-        logging.debug("Clicking Sign In with Email button...")
+        logging.info("Clicking Sign In with Email button...")
         driver.find_element(By.XPATH, '//*[@id="auth-container"]/button[2]').click()
         time.sleep(1)
 
-        logging.debug("Entering email address...")
+        logging.info("Entering email address...")
         email_input = driver.find_element(By.XPATH, '//*[@id="input-6"]')
         email_input.clear()
         email_input.send_keys(pl_email)
         time.sleep(1)
 
-        logging.debug("Entering password...")
+        logging.info("Entering password...")
         password_input = driver.find_element(By.XPATH, '//*[@id="input-8"]')
         password_input.clear()
         password_input.send_keys(pl_pass)
         time.sleep(1)
 
-        logging.debug("Clicking Sign In button...")
+        logging.info("Clicking Sign In button...")
         driver.find_element(By.XPATH, '//*[@id="auth-container"]/form/button').click()
         logging.info(f"Waiting {time_delay} seconds for login to complete.")
         time.sleep(time_delay)
@@ -156,7 +156,7 @@ def main():
         logging.info("Updating accounts in ProjectionLab...")
         for command in update_list:
             redacted_command = redact_api_key(command) # hide private info from logging
-            logging.debug(f"Executing command: {redacted_command}")
+            logging.info(f"Executing command: {redacted_command}")
             driver.execute_script(command)
             logging.info("Successfully executed command. Sleeping 1 sec")
             time.sleep(1)

--- a/sheets2projectionlab.py
+++ b/sheets2projectionlab.py
@@ -92,7 +92,8 @@ def main():
     sheet_instance.update_acell(dummy_cell, "Refresh Trigger")
     time.sleep(1)
     sheet_instance.update_acell(dummy_cell, original_value)  # Restore original value
-    time.sleep(1)
+    logging.info(f"Waiting {time_delay} after dummy value write (hopefully) ensure the sheet updates.")
+    time.sleep(time_delay)
 
     # List of accounts and balances to update
     # Should be a list of values matching this string:window.projectionlabPluginAPI.updateAccount('xxxxxxxxx-accountid', { balance: 33019.78 }, { key: 'xxxxxxxxxxx-apikey' })


### PR DESCRIPTION
Add short time-delays to the Google Sheet logic, plus write a new value to the sheet (then undo that write) to force the spreadsheet to refresh all functions - this was the only way I found to get `=GOOGLEFINANCE()` values to update every time the script is called. 

+Documentation updates